### PR TITLE
Fix hard-coded tag counts vol. 2

### DIFF
--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -55,7 +55,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    allKontentItemTag {
+    allKontentItemTag(filter: {preferred_language: {eq: "en-US"}}) {
       nodes {
         elements {
           title {

--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -28,7 +28,7 @@ class TagsRoute extends React.Component {
                             to={`/tags/${tag.elements.slug.value}/`}
                             className="tags__list-item-link"
                           >
-                            {tag.elements.title.value} (9)
+                            {tag.elements.title.value} ({tag.usedByContentItems.length})
                           </Link>
                         </li>
                       ))}
@@ -55,7 +55,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    allKontentItemTag(filter: {preferred_language: {eq: "en-US"}}) {
+    allKontentItemTag {
       nodes {
         elements {
           title {
@@ -63,6 +63,11 @@ export const pageQuery = graphql`
           }
           slug {
             value
+          }
+        }
+        usedByContentItems {
+          system {
+            codename
           }
         }
       }


### PR DESCRIPTION
### Motivation

Counts of articles under the tag on `/tags` page were hardcoded.

Used `usedByContentItems`field to get the count.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Check preview 💪 
